### PR TITLE
Run TravisCI tests in Vagrant (Ubuntu 20.04)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.sqlite
+*.vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
-dist: xenial
+dist: bionic
 
-language: go
-go: 
- - "1.13.x"
+# Cache the big Vagrant boxes
+cache:
+  directories:
+  - /home/travis/.vagrant.d/boxes
 
-env:
-  - GO111MODULE=on
-
-install: true
-
-before_install:
-  - sudo apt-get -y install linux-headers-$(uname -r)
-  - sudo add-apt-repository -y ppa:wireguard/wireguard
-  - sudo apt-get -q update
-  - sudo apt-get -y install wireguard
-
-script: sudo -E env "PATH=$PATH" go test -v
+script:
+- bash scripts/travis.sh

--- a/scripts/Vagrantfile
+++ b/scripts/Vagrantfile
@@ -1,0 +1,22 @@
+Vagrant.configure("2") do |config|
+    config.vm.box = "generic/ubuntu2004"
+
+    config.vm.define 'ubuntu'
+
+    # Vagrant boot needs more time on AppVeyor (see https://help.appveyor.com/discussions/problems/1247-vagrant-not-working-inside-appveyor)
+    config.vm.boot_timeout = 1800
+
+    # Prevent SharedFoldersEnableSymlinksCreate errors
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+    config.vm.provision "file", source: "../", destination: "dswg"
+    config.vm.provision "shell", path: "vagrant-bootstrap.sh"
+
+    config.vm.provider :virtualbox do |vb|
+        vb.name = 'ubuntu'
+        vb.memory = 512
+        vb.cpus = 1
+        # Vagrant needs this config on AppVeyor to spin up correctly (see https://help.appveyor.com/discussions/problems/1247-vagrant-not-working-inside-appveyor)
+        vb.customize ["modifyvm", :id, "--nictype1", "Am79C973"]
+        vb.customize ['modifyvm', :id, '--cableconnected1', 'on']
+    end
+end

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Install libvirt, KVM & Vagrant
+sudo apt-get update && sudo apt-get install -y bridge-utils dnsmasq-base ebtables libvirt-bin libvirt-dev qemu-kvm qemu-utils ruby-dev
+sudo wget -nv https://releases.hashicorp.com/vagrant/2.2.7/vagrant_2.2.7_x86_64.deb
+sudo dpkg -i vagrant_2.2.7_x86_64.deb
+vagrant --version
+sudo vagrant plugin install vagrant-libvirt
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $DIR
+
+sudo vagrant up --provider=libvirt
+sudo vagrant ssh -c "cd dswg && sudo /usr/bin/go test -v"

--- a/scripts/vagrant-bootstrap.sh
+++ b/scripts/vagrant-bootstrap.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sudo apt-get -y update
+sudo apt-get -y install golang
+sudo apt-get -y install wireguard


### PR DESCRIPTION
Travis was restricting the integration tests which needed wireguard to be loaded in the kernel.
Travis prevented loading wireguard kernel module properly for testing.
This workaround uses Vagrant to spawn a VM with Ubuntu 20.04 to run the tests.